### PR TITLE
fix: optional chaining in imdb's item.q

### DIFF
--- a/src/lib/api/imdb.ts
+++ b/src/lib/api/imdb.ts
@@ -52,7 +52,7 @@ export async function getImdbId(
   const possibleMovies = data.d.filter(
     (item) =>
       item.id.startsWith('tt') &&
-      ['feature', 'tv movie', 'video'].includes(item.q.toLowerCase())
+      ['feature', 'tv movie', 'video'].includes(item.q?.toLowerCase())
   )
 
   // if only one match, we assume it's correct


### PR DESCRIPTION
### Description:
imdb's response doesn't guarantee a `q` key, so this PR adds optional chaining when calling `toLowerCase`

#### Issues:
Closes #9
